### PR TITLE
GitHubとGitHubEnterpriseのどちらの設定も保存して使えるように

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -6,11 +6,36 @@
     <title>設定</title>
   </head>
   <body>
-    <h1>設定</h1>
-    <form class="setting">
+    <h1>pull-req-label</h1>
+    <h2>GitHub用 設定</h2>
+    <form id="form-github" class="setting">
       <div>
         <label>
-          APIプレフィックス("https://api.github.com/"とか"https://yourdomain.example.com/api/v3/"とか):<br />
+          APIプレフィックス(固定):<br />
+          <input type="text" class="api_prefix" size="64" value="https://api.github.com/" readonly />
+        </label>
+      </div>
+      <div>
+        <label>
+          ユーザー名:<br />
+          <input type="text" class="username" />
+        </label>
+      </div>
+      <div>
+        <label>
+          パスワード(Personal Access Tokensを推奨):<br />
+          <input type="text" class="password" />
+        </label>
+      </div>
+      <div>
+        <button type="submit" class="save">保存</button>
+      </div>
+    </form>
+    <h2>GitHubEnterprise用 設定</h2>
+    <form id="form-ghe" class="setting">
+      <div>
+        <label>
+          APIプレフィックス("https://yourdomain.example.com/api/v3/"等):<br />
           <input type="text" class="api_prefix" size="64" />
         </label>
       </div>

--- a/src/options.js
+++ b/src/options.js
@@ -1,21 +1,34 @@
 $(function() {
-    $('.api_prefix').val(localStorage.getItem('api_prefix'));
-    $('.username').val(localStorage.getItem('username'));
-    $('.password').val(localStorage.getItem('password'));
-
-    $('.setting').on('submit', function(event) {
-        var api_prefix = $('.api_prefix').val();
-        var username = $('.username').val();
-        var password = $('.password').val();
-        if (!api_prefix || !username || !password) {
-            $('.save').text('全項目を入力してください');
-            return false;
+    function getConfig(type, key) {
+        return localStorage.getItem(type + '-' + key);
+    }
+    function setConfig(type, key, value) {
+        localStorage.setItem(type + '-' + key, value);
+    }
+    ['github', 'ghe'].forEach(function(type, i) {
+        var $form = $('#form-'+type+'.setting');
+        if (!$form.find('.api_prefix').val()) {
+            $form.find('.api_prefix').val(getConfig(type, 'api_prefix'));
         }
+        $form.find('.username').val(getConfig(type, 'username'));
+        $form.find('.password').val(getConfig(type, 'password'));
 
-        localStorage.setItem('api_prefix', api_prefix);
-        localStorage.setItem('username', username);
-        localStorage.setItem('password', password);
-        $('.save').text('保存しました');
-        return false;
+
+        $form.on('submit', function(e) {
+            var api_prefix = $form.find('.api_prefix').val();
+            var username = $form.find('.username').val();
+            var password = $form.find('.password').val();
+            if (!api_prefix || !username || !password) {
+                $form.find('.save').text('全項目を入力してください');
+                return false;
+            }
+
+            setConfig(type, 'api_prefix', api_prefix);
+            setConfig(type, 'username', username);
+            setConfig(type, 'password', password);
+
+            $form.find('.save').text('保存しました');
+            return false;
+        });
     });
 });


### PR DESCRIPTION
これまでは GitHub用に設定するかGitHubEnterprise用に設定するかが排他的だったので、設定を倍にしてどちらも同時に利用できるようにしました。

実装がかなり雑ですが、とりあえず動くという感じです。

<img src="https://f.cloud.github.com/assets/6882/2063154/1e5c04fa-8cb0-11e3-96b7-54bcd361fa40.png" width=300>

そのうち、localStorageに複雑なデータいれるのがきついので、chrome.storageとか使えるようになればいいかもしれない。
